### PR TITLE
#3 Resolve build issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,1 @@
+FROM balenalib/raspberrypi3-node:11.14.0

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "engines": {
+    "node": ">=11.0.0"
+  },
   "scripts": {
     "preinstall": "bash deps.sh",
     "start": "node hello.js"


### PR DESCRIPTION
Default build used resin/raspberrypi3-node:10.10.0 which failed to build via BalenaCloud. 
Added engines.node which was also failing to build.